### PR TITLE
En 2382 empty image safari events

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -126,12 +126,14 @@ if (
 
 }
 
+const { isEmailOptInChecked = false } = donationData;
+
 // Donation Confirmation with no eCard
 if (is_non_ecard_donation_final_page) {
-    utag_data.page_category = 'don_emt_submit';
+    utag_data.page_category = isEmailOptInChecked ? 'don_emt_emo_submit' : 'don_emt_submit';
 
     if (mobilePhoneData && mobilePhoneData.phoneNumber) {
-        utag_data.page_category = 'don_emt_txt_submit';
+        utag_data.page_category = isEmailOptInChecked ? 'don_emt_emo_txt_submit' : 'don_emt_txt_submit';
         utag_data.text_signup_location = 'donation';
     }
 }
@@ -143,9 +145,9 @@ if (is_engrid_ecard_final_page || is_old_ecard_flow_final_page) {
     utag_data.form_name = productId;
     utag_data.product_id = [productId];
     if (mobilePhoneData && mobilePhoneData.phoneNumber) {
-        utag_data.page_category = 'don_emt_txt_ecrd_submit';
+        utag_data.page_category = isEmailOptInChecked ? 'don_emt_emo_txt_ecrd_submit' : 'don_emt_txt_ecrd_submit';
     } else {
-        utag_data.page_category = 'donation_ecard';
+        utag_data.page_category = isEmailOptInChecked ? 'don_emt_emo_ecrd_submit' : 'donation_ecard';
     }
 }
 /******** Successful Donations - eCard and non-eCard analytics End ********/

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -126,10 +126,10 @@ if (
 
 }
 
-const { isEmailOptInChecked = false } = donationData;
 
 // Donation Confirmation with no eCard
 if (is_non_ecard_donation_final_page) {
+    const { isEmailOptInChecked = false } = donationData;
     utag_data.page_category = isEmailOptInChecked ? 'don_emt_emo_submit' : 'don_emt_submit';
 
     if (mobilePhoneData && mobilePhoneData.phoneNumber) {
@@ -140,6 +140,7 @@ if (is_non_ecard_donation_final_page) {
 
 // Donation confirmation with eCard
 if (is_engrid_ecard_final_page || is_old_ecard_flow_final_page) {
+    const { isEmailOptInChecked = false } = donationData;
     const { campaignPageId, productId } = donationData;
     utag_data.donation_form_id = campaignPageId;
     utag_data.form_name = productId;

--- a/src/scss/forms/_event.scss
+++ b/src/scss/forms/_event.scss
@@ -871,7 +871,7 @@ a[href="javascript:history.back()"] {
   display: inline-block;
   margin-bottom: 3rem;
   &::before {
-    content: $icon-back;
+    // content: $icon-back;
     margin-right: 0.5rem;
   }
 }
@@ -898,7 +898,7 @@ a[href="javascript:history.back()"] {
     }
   }
   tr {
-    &:first-child,
+/*    &:first-child,
     &:nth-child(2) {
       td:first-child {
         &::before {
@@ -919,7 +919,7 @@ a[href="javascript:history.back()"] {
           content: $icon-time;
         }
       }
-    }
+    }*/
     @include media-breakpoint-down(md) {
       padding: 1rem 1.25rem;
       &:not(:last-child) {


### PR DESCRIPTION
Updated events.scss to remove svg image parameters from :before pseudo-classes that were applying to 4 areas on the thank you/receipt page of events. Those svgs did not load on any browser, but were showing as broken images in Safari.